### PR TITLE
Bugfix & balance improvements

### DIFF
--- a/Assets/Prefabs/BasicEnemyPrefab.prefab
+++ b/Assets/Prefabs/BasicEnemyPrefab.prefab
@@ -532,7 +532,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 42517f41ab27a5444b6e5d8e5fe5b1c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 1
+  damage: 3
 --- !u!114 &2757769580061605072
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -612,7 +612,8 @@ MonoBehaviour:
   pauseScreen: {fileID: 447068180}
   isPaused: 0
   optionsMenu: {fileID: 1382766746}
-  minutesToSurviveToWin: 3
+  timeToWin: 30
+  timeElapsed: 0
   secondsElapsed: 0
   minutesElapsed: 0
   killCount: 0
@@ -3151,8 +3152,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a6a0b5c66029d6744b86070c64810361, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxHealth: 20
-  currentHealth: 0
+  maxHealth: 50
+  currentHealth: 1
 --- !u!1001 &327020680
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -29706,7 +29707,7 @@ MonoBehaviour:
   movementSpeed: 1300
   maxStamina: 100
   currentStamina: 0
-  staminaDrainSpeed: 30
+  staminaDrainSpeed: 20
   staminaRegenerateSpeed: 30
   timeBeforeStaminaRegenerates: 2
   sprintSpeedMultiplier: 1.5
@@ -30355,8 +30356,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a6a0b5c66029d6744b86070c64810361, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxHealth: 1
-  currentHealth: 20
+  maxHealth: 100
+  currentHealth: 1
 --- !u!1 &4234103679715187305
 GameObject:
   m_ObjectHideFlags: 0
@@ -30605,9 +30606,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   movementSpeed: 1200
-  maxStamina: 120
+  maxStamina: 100
   currentStamina: 0
-  staminaDrainSpeed: 30
+  staminaDrainSpeed: 20
   staminaRegenerateSpeed: 30
   timeBeforeStaminaRegenerates: 2
   sprintSpeedMultiplier: 1.5

--- a/Assets/Scripts/Components/CollisionComponent.cs
+++ b/Assets/Scripts/Components/CollisionComponent.cs
@@ -8,6 +8,7 @@ public class CollisionComponent : MonoBehaviour
     private float playerGunDamage;
 
     private HealthComponent healthComponent;
+    private EnemyMovementController enemyMovementController;
     private Animator animator;
 
     private bool attacking = false;
@@ -17,6 +18,7 @@ public class CollisionComponent : MonoBehaviour
         playerGunDamage = player.GetComponent<GunController>().damage;
         
         healthComponent = GetComponent<HealthComponent>();
+        enemyMovementController = GetComponent<EnemyMovementController>();
         animator = GetComponent<Animator>();
     }
 
@@ -35,13 +37,14 @@ public class CollisionComponent : MonoBehaviour
     private void PlayAttackAnimation() {
         if (!attacking) {
             attacking = true;
-
             animator.SetTrigger("attack");
+            enemyMovementController.enabled = false;
             Invoke("AttackingHasFinished", animator.GetCurrentAnimatorStateInfo(0).length);
         }
     }
 
     private void AttackingHasFinished() {
         attacking = false;
+        enemyMovementController.enabled = true;
     }
 }

--- a/Assets/Scripts/Components/HealthComponent.cs
+++ b/Assets/Scripts/Components/HealthComponent.cs
@@ -5,15 +5,13 @@ using UnityEngine;
 public class HealthComponent : MonoBehaviour
 {   
     public float maxHealth;
-    [HideInInspector]public float currentHealth = 1;
-
+    [HideInInspector]public float currentHealth = 1; //Has to be set above 0 because DeathComponent will think the player is dead before 
+                                                     //before currentHealth is properly set otherwise. (Bug happens on restarts)
     private AudioManagerComponent audioManagerComponent;
 
     private void Start() {
-        audioManagerComponent = GetComponent<AudioManagerComponent>();
-
         currentHealth = maxHealth;
-
+        audioManagerComponent = GetComponent<AudioManagerComponent>();
     }
 
     public void DealDamage(float damageDealt) {

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -23,9 +23,10 @@ public class GameManager : MonoBehaviour
     [SerializeField]private GameObject optionsMenu;
 
     [Header("Trackers")]
-    public int minutesToSurviveToWin = 5;
-    [HideInInspector]public float secondsElapsed = 0;
-    [HideInInspector]public int minutesElapsed = 0;
+    public int timeToWin = 180;
+    public float timeElapsed = 0;
+    public float secondsElapsed = 0;
+    public float minutesElapsed = 0;
     [HideInInspector]public int killCount = 0;
 
     [Header("DifficultyScaling")]
@@ -68,6 +69,7 @@ public class GameManager : MonoBehaviour
         playerAudioManagerComponent = player.GetComponent<AudioManagerComponent>();
         playerAnimator = player.GetComponent<Animator>();
 
+        timeElapsed = 0;
         secondsElapsed = 0;
         minutesElapsed = 0;
         killCount = 0;
@@ -105,15 +107,11 @@ public class GameManager : MonoBehaviour
     }
 
     public void RunTimer() {
-        secondsElapsed += Time.deltaTime;
-        secondsElapsed = Mathf.Min(secondsElapsed, 60.0f);
-        if (secondsElapsed == 60.0f) {
-            secondsElapsed = 0.0f;
-            minutesElapsed++;
-        }
-        if (minutesElapsed >= minutesToSurviveToWin) {
-            GameOver();
-        }
+        timeElapsed += Time.deltaTime;
+        minutesElapsed = Mathf.FloorToInt(timeElapsed / 60);
+        secondsElapsed = Mathf.FloorToInt(timeElapsed % 60);
+
+        if (timeElapsed >= timeToWin) GameOver();
 
         difficultyScaleTimer += Time.deltaTime;
         if (difficultyScaleTimer >= difficultyScalingIntervalInSeconds) {

--- a/Assets/Scripts/UI/ActiveGameUI.cs
+++ b/Assets/Scripts/UI/ActiveGameUI.cs
@@ -33,7 +33,7 @@ public class ActiveGameUI : MonoBehaviour
 
         var currentHealth = healthComponent.currentHealth;
         var maxHealth = healthComponent.maxHealth;
-        healthText.SetText("Health: " + (currentHealth * 5).ToString("0"));
+        healthText.SetText("Health: " + currentHealth.ToString("0"));
         healthbarImage.fillAmount = currentHealth / maxHealth;
 
         var currentStamina = playerMovementController.currentStamina;

--- a/Assets/Scripts/UI/ActiveGameUI.cs
+++ b/Assets/Scripts/UI/ActiveGameUI.cs
@@ -29,7 +29,7 @@ public class ActiveGameUI : MonoBehaviour
     private void Update() {
         var minutesElapsed = GameManager.Instance.minutesElapsed;
         var secondsElapsed = GameManager.Instance.secondsElapsed;
-        timerText.SetText(minutesElapsed.ToString("00" + " : " + secondsElapsed.ToString("00")));
+        timerText.SetText(minutesElapsed.ToString("00") + " : " + secondsElapsed.ToString("00"));
 
         var currentHealth = healthComponent.currentHealth;
         var maxHealth = healthComponent.maxHealth;

--- a/Assets/Scripts/UI/GameOverScreen.cs
+++ b/Assets/Scripts/UI/GameOverScreen.cs
@@ -28,7 +28,10 @@ public class GameOverScreen : MonoBehaviour
     }
 
     private void UpdateUIText() {
-        timerText.SetText(GameManager.Instance.minutesElapsed.ToString("00") + " : " + GameManager.Instance.secondsElapsed.ToString("00"));
+        var minutesElapsed = GameManager.Instance.minutesElapsed;
+        var secondsElapsed = GameManager.Instance.secondsElapsed;
+        timerText.SetText(minutesElapsed.ToString("00") + " : " + secondsElapsed.ToString("00"));
+
         killCounterText.SetText(GameManager.Instance.killCount.ToString());
     }
 }

--- a/Assets/Scripts/UI/UpgradeScreen.cs
+++ b/Assets/Scripts/UI/UpgradeScreen.cs
@@ -35,16 +35,6 @@ public class UpgradeScreen : MonoBehaviour
         magazineUpgradeButton.interactable = SaveDataManager.pointsCollected > magazineUpgradeCost;
         speedUpgradeButton.interactable = SaveDataManager.pointsCollected > speedUpgradeCost;
 
-        // if (SaveDataManager.pointsCollected < damageUpgradeCost) {
-        //     damageUpgradeButton.interactable = false;
-        // }
-        // if (SaveDataManager.pointsCollected < magazineUpgradeCost) {
-        //     magazineUpgradeButton.interactable = false;
-        // }
-        // if (SaveDataManager.pointsCollected < speedUpgradeCost) {
-        //     speedUpgradeButton.interactable = false;
-        // }
-
         damageUpgradeCostText.SetText("Cost: " + damageUpgradeCost);
         magazineUpgradeCostText.SetText("Cost: " + magazineUpgradeCost);
         speedUpgradeCostText.SetText("Cost: " + speedUpgradeCost);
@@ -58,6 +48,7 @@ public class UpgradeScreen : MonoBehaviour
         SaveDataManager.pointsCollected -= damageUpgradeCost;
         SaveDataManager.damageUpgradeCount++;
         SaveDataManager.Instance.SaveDataInt("DamageUpgradeCount", SaveDataManager.damageUpgradeCount);
+        SaveDataManager.Instance.SaveDataInt("Points", SaveDataManager.pointsCollected);
     }
 
     public void PurchasedMagazineUpgrade() {


### PR DESCRIPTION
Insta-death bug on restarts fixed by initializing currentHealth at a value above 0.

Balanced the characters around.
- Decreased stamina drain 
- Decreased rifle's health to compensate for the much stronger weapon.